### PR TITLE
Support Serial object (closes #1)

### DIFF
--- a/async_modbus.py
+++ b/async_modbus.py
@@ -224,8 +224,10 @@ class _Stream:
             self.reader = self.writer = stream
         if hasattr(self.reader, "read_exactly"):
             self.readexactly = self.reader.read_exactly
-        else:
+        elif hasattr(self.reader, "readexactly"):
             self.readexactly = self.reader.readexactly
+        else:
+            self.readexactly = self.reader.read
         if inspect.iscoroutinefunction(self.writer.write):
             self._write_coro = None
 


### PR DESCRIPTION
Serial object does not have `readexactly(n)`. But the `read(n)` acts as `readexactly(n)` so we use it.