### PR TITLE
Make numpy optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ From within your favorite python environment type:
 
 `$ pip install async_modbus`
 
+Numpy will be used if installed. You can install it yourself, or include the optional dependency:
+
+`$ pip install async_modbus[numpy]`
+
 ## Library
 
 The core of the async_modbus library consists of a `modbus_for_url()` function

--- a/async_modbus.py
+++ b/async_modbus.py
@@ -7,16 +7,18 @@
 
 """Top-level package for async modbus library"""
 
-import struct
 import inspect
 import urllib.parse
 
-from umodbus import conf, functions
 from umodbus.client import tcp
 from umodbus.client.serial import rtu
-from umodbus.exceptions import IllegalDataValueError
 
-import numpy
+try:
+    import numpy  # noqa
+except ImportError:
+    pass
+else:
+    import umodbus_numpy  # noqa
 
 
 __author__ = """Tiago Coutinho"""
@@ -25,7 +27,7 @@ __version__ = "0.1.4"
 
 
 async def send_message_tcp(adu, reader, writer):
-    """ Send ADU over asyncio reader/writer and return parsed response.
+    """Send ADU over asyncio reader/writer and return parsed response.
 
     :param adu: Request ADU.
     :param reader: an async stream reader (ex: asyncio.StreamReader)
@@ -50,7 +52,7 @@ async def send_message_tcp(adu, reader, writer):
 
 
 async def send_message_rtu(adu, reader, writer):
-    """ Send ADU over serial to to server and return parsed response.
+    """Send ADU over serial to to server and return parsed response.
 
     :param adu: Request ADU.
     :param reader: an async stream reader (ex: asyncio.StreamReader)
@@ -77,135 +79,6 @@ async def send_message_rtu(adu, reader, writer):
 
 tcp._async_send_message = send_message_tcp
 rtu._async_send_message = send_message_rtu
-
-
-def unpack_bits(resp_pdu, req_pdu):
-    count = struct.unpack(">H", req_pdu[-2:])[0]
-    byte_count = struct.unpack(">B", resp_pdu[1:2])[0]
-    packed = numpy.frombuffer(resp_pdu, dtype="u1", offset=2, count=byte_count)
-    return numpy.unpackbits(packed, count=count, bitorder="little")
-
-
-def pack_bits(function_code, starting_address, values):
-    if not isinstance(values, numpy.ndarray):
-        values = numpy.array(values, dtype="u1")
-    packed = numpy.packbits(values, bitorder="little")
-    count = values.size
-    header = struct.pack(
-        ">BHHB", function_code, starting_address, count, (count + 7) // 8
-    )
-    return header + packed.tobytes()
-
-
-def unpack_16bits(resp_pdu, req_pdu):
-    count = struct.unpack(">H", req_pdu[-2:])[0]
-    dtype = ">{}2".format("i" if conf.SIGNED_VALUES else "u")
-    return numpy.frombuffer(resp_pdu, dtype=dtype, count=count, offset=2)
-
-
-def pack_16bits(function_code, starting_address, values):
-    dtype = ">{}2".format("i" if conf.SIGNED_VALUES else "u")
-    values = numpy.array(values, dtype=dtype, copy=False)
-    header = struct.pack(
-        ">BHHB", function_code, starting_address, values.size, values.nbytes
-    )
-    return header + values.tobytes()
-
-
-class ReadCoils(functions.ReadCoils):
-    @classmethod
-    def create_from_response_pdu(cls, resp_pdu, req_pdu):
-        """ Create instance from response PDU.
-
-        Response PDU is required together with the quantity of coils read.
-
-        :param resp_pdu: Byte array with request PDU.
-        :param quantity: Number of coils read.
-        :return: Instance of :class:`ReadCoils`.
-        """
-        read_coils = cls()
-        read_coils.data = unpack_bits(resp_pdu, req_pdu)
-        read_coils.quantity = read_coils.data.size
-        return read_coils
-
-
-class ReadDiscreteInputs(functions.ReadDiscreteInputs):
-    @classmethod
-    def create_from_response_pdu(cls, resp_pdu, req_pdu):
-        """ Create instance from response PDU.
-
-        Response PDU is required together with the quantity of inputs read.
-
-        :param resp_pdu: Byte array with request PDU.
-        :param quantity: Number of inputs read.
-        :return: Instance of :class:`ReadDiscreteInputs`.
-        """
-        read_discrete_inputs = cls()
-        read_discrete_inputs.data = unpack_bits(resp_pdu, req_pdu)
-        read_discrete_inputs.quantity = read_discrete_inputs.data.size
-        return read_discrete_inputs
-
-
-class ReadHoldingRegisters(functions.ReadHoldingRegisters):
-    @classmethod
-    def create_from_response_pdu(cls, resp_pdu, req_pdu):
-        """ Create instance from response PDU.
-
-        Response PDU is required together with the number of registers read.
-
-        :param resp_pdu: Byte array with request PDU.
-        :param quantity: Number of registers to read.
-        :return: Instance of :class:`ReadHoldingRegisters`.
-        """
-        read_holding_registers = cls()
-        read_holding_registers.data = unpack_16bits(resp_pdu, req_pdu)
-        read_holding_registers.quantity = read_holding_registers.data.size
-        return read_holding_registers
-
-
-class ReadInputRegisters(functions.ReadInputRegisters):
-    @classmethod
-    def create_from_response_pdu(cls, resp_pdu, req_pdu):
-        """ Create instance from response PDU.
-
-        Response PDU is required together with the number of registers read.
-
-        :param resp_pdu: Byte array with request PDU.
-        :param quantity: Number of coils read.
-        :return: Instance of :class:`ReadCoils`.
-        """
-        read_input_registers = cls()
-        read_input_registers.data = unpack_16bits(resp_pdu, req_pdu)
-        read_input_registers.quantity = read_input_registers.data.size
-        return read_input_registers
-
-
-def request_pdu_coils(self):
-    if self.starting_address is None or self._values is None:
-        raise IllegalDataValueError
-    return pack_bits(self.function_code, self.starting_address, self._values)
-
-
-def request_pdu_registers(self):
-    if self.starting_address is None or self._values is None:
-        raise IllegalDataValueError
-    return pack_16bits(self.function_code, self.starting_address, self._values)
-
-
-# Patch umodbus to do our biding (which is to handle numpy arrays)
-functions.WriteMultipleCoils.request_pdu = property(request_pdu_coils)
-functions.WriteMultipleRegisters.request_pdu = property(request_pdu_registers)
-
-
-function_code_to_function_map = {
-    functions.READ_COILS: ReadCoils,
-    functions.READ_DISCRETE_INPUTS: ReadDiscreteInputs,
-    functions.READ_HOLDING_REGISTERS: ReadHoldingRegisters,
-    functions.READ_INPUT_REGISTERS: ReadInputRegisters,
-}
-
-
-functions.function_code_to_function_map.update(function_code_to_function_map)
 
 
 class _Stream:
@@ -238,6 +111,7 @@ class _Stream:
                 assert self._write_coro is not None
                 await self._write_coro
                 self._write_coro = None
+
         else:
             write = self.writer.write
             drain = self.writer.drain

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 
 """The setup script."""
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 with open("README.md") as readme_file:
     readme = readme_file.read()
@@ -16,13 +16,16 @@ with open("README.md") as readme_file:
 with open("HISTORY.md") as history_file:
     history = history_file.read()
 
-requirements = [
-    "umodbus", "connio", "numpy"
-]
+requirements = ["umodbus", "connio"]
 
 setup_requirements = ["pytest-runner"]
 
 test_requirements = ["pytest>=3"]
+
+extras_require = {
+    "numpy": ["numpy"],
+}
+
 
 setup(
     author="Tiago Coutinho",
@@ -41,6 +44,7 @@ setup(
         "Programming Language :: Python :: 3.9",
     ],
     description="Async ModBus python library",
+    extras_require=extras_require,
     install_requires=requirements,
     license="GNU General Public License v3",
     long_description=readme + "\n\n" + history,
@@ -48,7 +52,7 @@ setup(
     include_package_data=True,
     keywords="async_modbus, asyncio, modbus",
     name="async_modbus",
-    py_modules=['async_modbus'],
+    py_modules=["async_modbus"],
     setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,

--- a/umodbus_numpy.py
+++ b/umodbus_numpy.py
@@ -1,0 +1,133 @@
+"""Patch umodbus to use numpy."""
+import struct
+
+import numpy
+from umodbus import conf, functions
+from umodbus.exceptions import IllegalDataValueError
+
+
+def unpack_bits(resp_pdu, req_pdu):
+    count = struct.unpack(">H", req_pdu[-2:])[0]
+    byte_count = struct.unpack(">B", resp_pdu[1:2])[0]
+    packed = numpy.frombuffer(resp_pdu, dtype="u1", offset=2, count=byte_count)
+    return numpy.unpackbits(packed, count=count, bitorder="little")
+
+
+def pack_bits(function_code, starting_address, values):
+    if not isinstance(values, numpy.ndarray):
+        values = numpy.array(values, dtype="u1")
+    packed = numpy.packbits(values, bitorder="little")
+    count = values.size
+    header = struct.pack(
+        ">BHHB", function_code, starting_address, count, (count + 7) // 8
+    )
+    return header + packed.tobytes()
+
+
+def unpack_16bits(resp_pdu, req_pdu):
+    count = struct.unpack(">H", req_pdu[-2:])[0]
+    dtype = ">{}2".format("i" if conf.SIGNED_VALUES else "u")
+    return numpy.frombuffer(resp_pdu, dtype=dtype, count=count, offset=2)
+
+
+def pack_16bits(function_code, starting_address, values):
+    dtype = ">{}2".format("i" if conf.SIGNED_VALUES else "u")
+    values = numpy.array(values, dtype=dtype, copy=False)
+    header = struct.pack(
+        ">BHHB", function_code, starting_address, values.size, values.nbytes
+    )
+    return header + values.tobytes()
+
+
+class ReadCoils(functions.ReadCoils):
+    @classmethod
+    def create_from_response_pdu(cls, resp_pdu, req_pdu):
+        """Create instance from response PDU.
+
+        Response PDU is required together with the quantity of coils read.
+
+        :param resp_pdu: Byte array with request PDU.
+        :param quantity: Number of coils read.
+        :return: Instance of :class:`ReadCoils`.
+        """
+        read_coils = cls()
+        read_coils.data = unpack_bits(resp_pdu, req_pdu)
+        read_coils.quantity = read_coils.data.size
+        return read_coils
+
+
+class ReadDiscreteInputs(functions.ReadDiscreteInputs):
+    @classmethod
+    def create_from_response_pdu(cls, resp_pdu, req_pdu):
+        """Create instance from response PDU.
+
+        Response PDU is required together with the quantity of inputs read.
+
+        :param resp_pdu: Byte array with request PDU.
+        :param quantity: Number of inputs read.
+        :return: Instance of :class:`ReadDiscreteInputs`.
+        """
+        read_discrete_inputs = cls()
+        read_discrete_inputs.data = unpack_bits(resp_pdu, req_pdu)
+        read_discrete_inputs.quantity = read_discrete_inputs.data.size
+        return read_discrete_inputs
+
+
+class ReadHoldingRegisters(functions.ReadHoldingRegisters):
+    @classmethod
+    def create_from_response_pdu(cls, resp_pdu, req_pdu):
+        """Create instance from response PDU.
+
+        Response PDU is required together with the number of registers read.
+
+        :param resp_pdu: Byte array with request PDU.
+        :param quantity: Number of registers to read.
+        :return: Instance of :class:`ReadHoldingRegisters`.
+        """
+        read_holding_registers = cls()
+        read_holding_registers.data = unpack_16bits(resp_pdu, req_pdu)
+        read_holding_registers.quantity = read_holding_registers.data.size
+        return read_holding_registers
+
+
+class ReadInputRegisters(functions.ReadInputRegisters):
+    @classmethod
+    def create_from_response_pdu(cls, resp_pdu, req_pdu):
+        """Create instance from response PDU.
+
+        Response PDU is required together with the number of registers read.
+
+        :param resp_pdu: Byte array with request PDU.
+        :param quantity: Number of coils read.
+        :return: Instance of :class:`ReadCoils`.
+        """
+        read_input_registers = cls()
+        read_input_registers.data = unpack_16bits(resp_pdu, req_pdu)
+        read_input_registers.quantity = read_input_registers.data.size
+        return read_input_registers
+
+
+def request_pdu_coils(self):
+    if self.starting_address is None or self._values is None:
+        raise IllegalDataValueError
+    return pack_bits(self.function_code, self.starting_address, self._values)
+
+
+def request_pdu_registers(self):
+    if self.starting_address is None or self._values is None:
+        raise IllegalDataValueError
+    return pack_16bits(self.function_code, self.starting_address, self._values)
+
+
+# Patch umodbus to do our bidding (which is to handle numpy arrays)
+functions.WriteMultipleCoils.request_pdu = property(request_pdu_coils)
+functions.WriteMultipleRegisters.request_pdu = property(request_pdu_registers)
+
+function_code_to_function_map = {
+    functions.READ_COILS: ReadCoils,
+    functions.READ_DISCRETE_INPUTS: ReadDiscreteInputs,
+    functions.READ_HOLDING_REGISTERS: ReadHoldingRegisters,
+    functions.READ_INPUT_REGISTERS: ReadInputRegisters,
+}
+
+functions.function_code_to_function_map.update(function_code_to_function_map)


### PR DESCRIPTION
First attempt to make numpy optional

Moved all numpy code to dedicated file, importing when numpy exists. 
Another approach would be an optional if, but that would also indent all the code and create a big change

```
try:
  import numpy
except ImportError:
  numpy = None

-- snip --

if numpy:
  # code here
```

but it does seem to make sense in a separate file