### PR TITLE
Extra protocol

### DIFF
--- a/async_modbus/core.py
+++ b/async_modbus/core.py
@@ -210,7 +210,7 @@ class AsyncClient:
         :param address: The register address
         :param value: value to write
         """
-        request = self.protocol.protocol.write_single_register(slave_id, address, value)
+        request = self.protocol.write_single_register(slave_id, address, value)
         return await self._send_message(request)
 
     async def write_coils(self, slave_id, starting_address, values):


### PR DESCRIPTION
There seems to be an extra `protocol.protocol` here

```python
  File "/usr/src/app/async_modbus.py", line 212, in write_register
    request = self.protocol.protocol.write_single_register(slave_id, address, value)
AttributeError: module 'umodbus.client.serial.rtu' has no attribute 'protocol'
```