### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ python_requires = >=3.6
 include_package_data = True
 tests_require = pytest >=3
 zip_safe = true
+install_requires = 
+  umodbus
+  connio
 
 [options.extras_require]
 numpy =


### PR DESCRIPTION
Install_requires seems to have been missed?

```
>pip install async_modbus  
Collecting async_modbus
  Downloading async_modbus-0.2.0-py3-none-any.whl (9.2 kB)
Installing collected packages: async-modbus
Successfully installed async-modbus-0.2.0
```

The optional numpy works ok

```
>pip install async_modbus[numpy]
Requirement already satisfied: async_modbus[numpy] in c:\python38\lib\site-packages (0.2.0)
Collecting numpy
  Using cached numpy-1.22.2-cp38-cp38-win_amd64.whl (14.7 MB)
Installing collected packages: numpy
Successfully installed numpy-1.22.2
```