### PR TITLE
Exclude test files from wheel contents

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,9 @@ tests_require =
 	pytest-cov
 zip_safe = true
 
+[options.packages.find]
+include = async_modbus*
+
 [options.extras_require]
 numpy = 
 	numpy>=1.1


### PR DESCRIPTION
It's generally recommended that test files only be included in the sdist, not wheel.

`dist-info/RECORD` diff
```diff
 async_modbus/__init__.py,sha256=Fm2SJSaCCqCE6FvKLcRCoHvdLhMRTEcPwUEfxgRbxl4,451
 async_modbus/core.py,sha256=mVcjAUugt3PeHz4zRqe-pUnHK3xe2pAs3IZkniocA2g,9139
 async_modbus/umodbus_numpy.py,sha256=6hXxzkCRccogEiicNjj5NSMSpyZVghm-bx372QLffhA,5289
 async_modbus-0.2.2.dist-info/licenses/LICENSE,sha256=88ujviYrK9Uy-mEn9VuC7PY86P-ER4Mq4sxKDBCD59c,1543
-tests/__init__.py,sha256=KXo0TjKwZ2Tfr6MyQhVnibqSDV19xyIkbgeIKIUjj0g,42
-tests/test_async_modbus.py,sha256=wvbhYQ85Huy_u9gqzVaPpKy__ucTkeCFhUNByMtHLaQ,11957
 async_modbus-0.2.2.dist-info/METADATA,sha256=2ickbNrSaCoNN4nhDtNW3nOKFj2biN7u_XUs9-xBaiY,8008
 async_modbus-0.2.2.dist-info/WHEEL,sha256=_zCd3N1l69ArxyTb8rzEoP9TpbYXkqRFSNOD5OuxnTs,91
-async_modbus-0.2.2.dist-info/top_level.txt,sha256=5Yv3CQBqHAp188YnCaOhsVLSxlwytGZAe6M_ylgL3so,19
+async_modbus-0.2.2.dist-info/top_level.txt,sha256=SZfDloqDY6xw2LySHYR3cL0W3iy56DG-NJV7i7Yw730,13
 async_modbus-0.2.2.dist-info/zip-safe,sha256=AbpHGcgLb-kRsJGnwFEktk7uzpZOCcBY74-YBdrKVGs,1
 async_modbus-0.2.2.dist-info/RECORD,,
```

Ref: https://github.com/home-assistant/core/pull/150630